### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+# Ignore img file.
+public/uploads/*


### PR DESCRIPTION
# what
uploads配下のファイル（画像ファイル）に関してGit追跡不要とした。

# why
今後実装するにあたり、コミット対象とならないため。
大量の不要ファイルがコミット対象としてあがることが予想されるため。